### PR TITLE
Add Yamamura Prize official documentation link

### DIFF
--- a/_pages/cv.md
+++ b/_pages/cv.md
@@ -22,7 +22,7 @@ header:
   * Advisor: Prof. Toshihide Yamashita
   
 * **Doctor of Medicine (M.D.)**, Osaka University Faculty of Medicine, 2015 - 2021
-  * **Yamamura Prize** (graduation honors, top 3 out of 115 graduates)
+  * **[Yamamura Prize](https://www.med.osaka-u.ac.jp/wp-content/uploads/2025/06/R6YamamuraPrizeWinner-List.pdf)** (graduation honors, top 3 out of 115 graduates)
   
 * **Research Internship**, Barkla X-ray Laboratory of Biophysics, University of Liverpool, UK, Feb - Mar 2018
   * Supervisor: Prof. Samar Hasnain
@@ -101,7 +101,7 @@ header:
 ## Awards & Honors
 ------
 * **JSPS Research Fellowship for Young Scientists (DC1)**, 2023-2026 ([KAKENHI-PROJECT-24KJ1662](https://kaken.nii.ac.jp/ja/grant/KAKENHI-PROJECT-24KJ1662/))
-* **Yamamura Prize** (graduation honors), Osaka University Faculty of Medicine, 2021
+* **[Yamamura Prize](https://www.med.osaka-u.ac.jp/wp-content/uploads/2025/06/R6YamamuraPrizeWinner-List.pdf)** (graduation honors), Osaka University Faculty of Medicine, 2021
 * **Pathophysiology Excellence Award**, Japanese Association of Anatomists, 2021
 * **Junior Investigator Poster Award**, Japan Neuroscience Society, 2018
 * **Intellectual Property Management Prize** & **Risk Management Prize**, Medical Device Design Course, 2023


### PR DESCRIPTION
## Summary
Added official link to Yamamura Prize documentation from Osaka University Medical School.

## Changes
- Added hyperlink to Yamamura Prize in Education section
- Added hyperlink to Yamamura Prize in Awards & Honors section
- Link points to official PDF: https://www.med.osaka-u.ac.jp/wp-content/uploads/2025/06/R6YamamuraPrizeWinner-List.pdf

## Why
This provides verification and additional context for this prestigious award, allowing viewers to see the official documentation.

🤖 Generated with [Claude Code](https://claude.ai/code)