### PR TITLE
Add Kishimoto International Exchange Scholarship documentation link

### DIFF
--- a/_pages/cv.md
+++ b/_pages/cv.md
@@ -50,6 +50,7 @@ header:
 * **Spring Research Internship**, Samar Hasnain Laboratory, University of Liverpool, Feb - Mar 2018
   * Expressed and purified SOD1 and TDP43 proteins in E. coli
   * Performed protein crystallization and 3D structural analysis
+  * [Kishimoto International Exchange Scholarship](https://www.med.osaka-u.ac.jp/wp-content/uploads/gakuseishien/sholarship/h29Kishimoto/MD_foreig_short_stay.pdf)
 
 ## Publications
 ------
@@ -105,7 +106,7 @@ header:
 * **Pathophysiology Excellence Award**, Japanese Association of Anatomists, 2021
 * **Junior Investigator Poster Award**, Japan Neuroscience Society, 2018
 * **Intellectual Property Management Prize** & **Risk Management Prize**, Medical Device Design Course, 2023
-* **Kishimoto International Exchange Scholarship**, 2018
+* **[Kishimoto International Exchange Scholarship](https://www.med.osaka-u.ac.jp/wp-content/uploads/gakuseishien/sholarship/h29Kishimoto/MD_foreig_short_stay.pdf)**, 2018
 
 ## Professional Development
 ------


### PR DESCRIPTION
## Summary
Added official link to Kishimoto International Exchange Scholarship documentation.

## Changes
- Added hyperlink to Kishimoto scholarship in Research Experience section (Spring Research Internship)
- Added hyperlink to Kishimoto scholarship in Awards & Honors section
- Link points to official PDF: https://www.med.osaka-u.ac.jp/wp-content/uploads/gakuseishien/sholarship/h29Kishimoto/MD_foreig_short_stay.pdf

## Context
リンク先は「MD研究者育成プログラム参加学生に対する支援」という資料で、その中の5番のS.Nに該当します。
(The linked document is about support for MD researcher training program participants, and this corresponds to number 5 S.N. in the document.)

## Why
This provides official documentation for the Kishimoto scholarship that supported the research internship at University of Liverpool.

🤖 Generated with [Claude Code](https://claude.ai/code)