### PR TITLE
Add Zambia global health research internship

### DIFF
--- a/_pages/cv.md
+++ b/_pages/cv.md
@@ -51,6 +51,12 @@ header:
   * Expressed and purified SOD1 and TDP43 proteins in E. coli
   * Performed protein crystallization and 3D structural analysis
 
+* **Global Health Research Internship**, JICA/University Teaching Hospital, Lusaka, Zambia, Aug 2018
+  * Investigated TB/AIDS co-infection epidemiology in sub-Saharan Africa
+  * Conducted field research at local healthcare facilities
+  * Presented findings at the 36th Annual Meeting of Japan Association for Global Health
+  * [Kishimoto International Exchange Scholarship](https://www.med.osaka-u.ac.jp/wp-content/uploads/gakuseishien/sholarship/4_kikaku1-G3.pdf)
+
 ## Publications
 ------
 1. **Sada, N.**, Fujita, Y., Mizuta, N. et al. Inhibition of HDAC increases BDNF expression and promotes neuronal rewiring and functional recovery after brain injury. *Cell Death & Disease* 11, 655 (2020). [https://doi.org/10.1038/s41419-020-02897-w](https://doi.org/10.1038/s41419-020-02897-w)
@@ -117,7 +123,10 @@ header:
 
 * **Training Program for MD-PhD Researchers**, Osaka University Faculty of Medicine, Apr 2016 - Mar 2021
 
-* **JICA Intern**, Global Health Project on TB/AIDS co-infection in Zambia, Aug 2018
+* **Global Health Research Internship**, JICA Project on TB/AIDS co-infection, Lusaka, Zambia, Aug 2018
+  * Studied public health challenges in developing countries
+  * Participated in field research on infectious disease control
+  * [Kishimoto International Exchange Scholarship Report](https://www.med.osaka-u.ac.jp/wp-content/uploads/gakuseishien/sholarship/4_kikaku1-G3.pdf)
 
 ## Technical Skills
 ------


### PR DESCRIPTION
## Summary
Added comprehensive information about the global health research internship in Zambia (August 2018) with official documentation link.

## Changes Made

### 1. Research Experience Section
- Added new entry for Global Health Research Internship at JICA/University Teaching Hospital, Lusaka, Zambia
- Included research activities on TB/AIDS co-infection epidemiology
- Referenced conference presentation outcome

### 2. Professional Development Section  
- Updated existing JICA Intern entry with more descriptive title and details
- Added structured bullet points for activities
- Added Kishimoto scholarship report link

### Documentation
- Link to official report: https://www.med.osaka-u.ac.jp/wp-content/uploads/gakuseishien/sholarship/4_kikaku1-G3.pdf
- This internship was also supported by Kishimoto International Exchange Scholarship

## Impact
This addition provides a complete picture of international research experiences during medical school, showing early engagement with global health issues that connects to current neuroscience research interests.

🤖 Generated with [Claude Code](https://claude.ai/code)