### PR TITLE
Add year clarification for Yamamura Prize in linked document

### DIFF
--- a/_pages/cv.md
+++ b/_pages/cv.md
@@ -22,7 +22,7 @@ header:
   * Advisor: Prof. Toshihide Yamashita
   
 * **Doctor of Medicine (M.D.)**, Osaka University Faculty of Medicine, 2015 - 2021
-  * **[Yamamura Prize](https://www.med.osaka-u.ac.jp/wp-content/uploads/2025/06/R6YamamuraPrizeWinner-List.pdf)** (graduation honors, top 3 out of 115 graduates)
+  * **[Yamamura Prize](https://www.med.osaka-u.ac.jp/wp-content/uploads/2025/06/R6YamamuraPrizeWinner-List.pdf)** (graduation honors, top 3 out of 115 graduates) - *See 令和2年度 (2020) in the linked document*
   
 * **Research Internship**, Barkla X-ray Laboratory of Biophysics, University of Liverpool, UK, Feb - Mar 2018
   * Supervisor: Prof. Samar Hasnain
@@ -108,7 +108,7 @@ header:
 ## Awards & Honors
 ------
 * **JSPS Research Fellowship for Young Scientists (DC1)**, 2023-2026 ([KAKENHI-PROJECT-24KJ1662](https://kaken.nii.ac.jp/ja/grant/KAKENHI-PROJECT-24KJ1662/))
-* **[Yamamura Prize](https://www.med.osaka-u.ac.jp/wp-content/uploads/2025/06/R6YamamuraPrizeWinner-List.pdf)** (graduation honors), Osaka University Faculty of Medicine, 2021
+* **[Yamamura Prize](https://www.med.osaka-u.ac.jp/wp-content/uploads/2025/06/R6YamamuraPrizeWinner-List.pdf)** (graduation honors), Osaka University Faculty of Medicine, 2021 - *See 令和2年度 (2020) in the linked document*
 * **Pathophysiology Excellence Award**, Japanese Association of Anatomists, 2021
 * **Junior Investigator Poster Award**, Japan Neuroscience Society, 2018
 * **Intellectual Property Management Prize** & **Risk Management Prize**, Medical Device Design Course, 2023


### PR DESCRIPTION
## Summary
Added clarification to help readers find the correct year in the Yamamura Prize winner list PDF.

## Problem
The linked PDF contains multiple years of Yamamura Prize winners, making it difficult to locate the specific entry without guidance.

## Solution
Added the note: *"See 令和2年度 (2020) in the linked document"* to both:
- Education section
- Awards & Honors section

This ensures readers can quickly find the correct year (令和2年度/2020) in the comprehensive list.

## Note
The graduation was in 2021, but the prize is listed under 令和2年度 (2020 academic year) in the official document.

🤖 Generated with [Claude Code](https://claude.ai/code)