### PR TITLE
Add TOEFL iBT score to language proficiency

### DIFF
--- a/_pages/cv.md
+++ b/_pages/cv.md
@@ -136,7 +136,7 @@ header:
 * **Animal Research**: Mouse behavioral testing, Stereotaxic surgery, TBI models
 * **Protein Biochemistry**: Protein expression and purification, Crystallography
 * **Data Analysis**: Statistical analysis, Omics data interpretation
-* **Languages**: Japanese (Native), English (Professional proficiency)
+* **Languages**: Japanese (Native), English (Professional proficiency - TOEFL iBT 92/120)
 
 ---
 *Last updated: June 2025*


### PR DESCRIPTION
## Summary
Added TOEFL iBT score to demonstrate quantifiable English language proficiency.

## Change
- Updated Languages line in Technical Skills section:
  ```
  Japanese (Native), English (Professional proficiency - TOEFL iBT 92/120)
  ```

## Rationale
- TOEFL iBT score provides objective measurement of English proficiency
- Score of 92/120 corresponds to CEFR B2-C1 level (upper intermediate to advanced)
- Important for international research collaborations and opportunities
- Standard requirement for many international programs and positions

🤖 Generated with [Claude Code](https://claude.ai/code)