### PR TITLE
Add link to MedTech Entrepreneurship Symposium presentation

### DIFF
--- a/_pages/cv.md
+++ b/_pages/cv.md
@@ -65,7 +65,7 @@ header:
 ## Selected Conference Presentations
 ------
 ### Oral Presentations
-* **Prevention of neurological complications of surgery by developing a nerve-sparing navigation system**  
+* **[Prevention of neurological complications of surgery by developing a nerve-sparing navigation system](https://link-j.g.kuroco-img.app/v=1730801790/files/topics/44108_ext_6_0.pdf)**  
   Sada N. and Kisaki T., MedTech Entrepreneurship Symposium, Osaka, Japan, Jun 2024
 
 * **Traumatic brain injury and basic research**  


### PR DESCRIPTION
## Summary
Added link to the official documentation for the MedTech Entrepreneurship Symposium presentation.

## Change
Made the presentation title clickable with link to the official PDF:
- **Title**: "Prevention of neurological complications of surgery by developing a nerve-sparing navigation system"
- **Event**: MedTech Entrepreneurship Symposium, Osaka, Japan, June 2024
- **Link**: https://link-j.g.kuroco-img.app/v=1730801790/files/topics/44108_ext_6_0.pdf

## Context
This presentation was part of the TRACS program (メディカル・ヘルスケアデバイス　スタートアップ経営者育成プログラム) culminating event, presented to 300+ participants as mentioned in the Professional Development section.

🤖 Generated with [Claude Code](https://claude.ai/code)