### PR TITLE
Restructure CV: Properly categorize scholarships vs awards

### DIFF
--- a/_pages/cv.md
+++ b/_pages/cv.md
@@ -50,13 +50,13 @@ header:
 * **Spring Research Internship**, Samar Hasnain Laboratory, University of Liverpool, Feb - Mar 2018
   * Expressed and purified SOD1 and TDP43 proteins in E. coli
   * Performed protein crystallization and 3D structural analysis
-  * [Kishimoto International Exchange Scholarship](https://www.med.osaka-u.ac.jp/wp-content/uploads/gakuseishien/sholarship/h29Kishimoto/MD_foreig_short_stay.pdf)
+  * [Kishimoto International Exchange Scholarship](https://www.med.osaka-u.ac.jp/wp-content/uploads/gakuseishien/sholarship/h29Kishimoto/MD_foreig_short_stay.pdf) - Structural biology of neurodegenerative disease proteins
 
 * **Global Health Research Internship**, JICA/University Teaching Hospital, Lusaka, Zambia, Aug 2018
   * Investigated TB/AIDS co-infection epidemiology in sub-Saharan Africa
   * Conducted field research at local healthcare facilities
   * Presented findings at the 36th Annual Meeting of Japan Association for Global Health
-  * [Kishimoto International Exchange Scholarship](https://www.med.osaka-u.ac.jp/wp-content/uploads/gakuseishien/sholarship/4_kikaku1-G3.pdf)
+  * [Kishimoto International Exchange Scholarship](https://www.med.osaka-u.ac.jp/wp-content/uploads/gakuseishien/sholarship/4_kikaku1-G3.pdf) - Public health fieldwork in resource-limited settings
 
 ## Publications
 ------
@@ -117,7 +117,6 @@ header:
 * **Pathophysiology Excellence Award**, Japanese Association of Anatomists, 2021
 * **Junior Investigator Poster Award**, Japan Neuroscience Society, 2018
 * **Intellectual Property Management Prize** & **Risk Management Prize**, Medical Device Design Course, 2023
-* **[Kishimoto International Exchange Scholarship](https://www.med.osaka-u.ac.jp/wp-content/uploads/gakuseishien/sholarship/h29Kishimoto/MD_foreig_short_stay.pdf)**, 2018
 
 ## Professional Development
 ------
@@ -129,10 +128,9 @@ header:
 
 * **Training Program for MD-PhD Researchers**, Osaka University Faculty of Medicine, Apr 2016 - Mar 2021
 
-* **Global Health Research Internship**, JICA Project on TB/AIDS co-infection, Lusaka, Zambia, Aug 2018
-  * Studied public health challenges in developing countries
-  * Participated in field research on infectious disease control
-  * [Kishimoto International Exchange Scholarship Report](https://www.med.osaka-u.ac.jp/wp-content/uploads/gakuseishien/sholarship/4_kikaku1-G3.pdf)
+* **JICA Global Health Program**, Lusaka, Zambia, Aug 2018
+  * Studied public health challenges and TB/AIDS co-infection in sub-Saharan Africa
+  * Participated in field research on infectious disease control at University Teaching Hospital
 
 ## Technical Skills
 ------


### PR DESCRIPTION
## Summary
Restructured CV to properly distinguish between awards and scholarships, with clearer descriptions.

## Changes

### 1. Removed from Awards & Honors
- Kishimoto International Exchange Scholarship (2018)
- Reason: Scholarships are funding support, not competitive awards

### 2. Enhanced Research Experience entries
- **Liverpool internship**: Added "Structural biology of neurodegenerative disease proteins"
- **Zambia internship**: Added "Public health fieldwork in resource-limited settings"
- These brief descriptions provide context without requiring PDF downloads

### 3. Consolidated Professional Development
- Removed duplicate Kishimoto scholarship link from JICA entry
- Streamlined description to avoid redundancy with Research Experience section

## Result
- Clearer distinction between competitive awards (prizes, honors) and funding (scholarships, fellowships)
- Research Experience section now shows both the activity AND the funding source with context
- Reduced redundancy while maintaining complete information

🤖 Generated with [Claude Code](https://claude.ai/code)