### PR TITLE
Fix: Resolve favicon 404 and color picker positioning

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -8,7 +8,7 @@
 <link rel="icon" type="image/png" href="{{ base_path }}/images/favicon-32x32.png" sizes="32x32"/>
 <link rel="icon" type="image/png" href="{{ base_path }}/images/favicon-192x192.png" sizes="192x192"/>
 <link rel="manifest" href="{{ base_path }}/images/manifest.json"/>
-<link rel="icon" href="/images/favicon.ico"/>
+<link rel="icon" href="{{ base_path }}/images/favicon.ico"/>
 <meta name="theme-color" content="#ffffff"/>
 <link rel="stylesheet" href="{{ base_path }}/assets/css/academicons.css"/>
 

--- a/assets/js/color-picker-active.js
+++ b/assets/js/color-picker-active.js
@@ -62,24 +62,14 @@
       </div>
     `;
 
-    // Find or create container
-    let colorPickerContainer = document.querySelector('.color-picker-container');
+    // Create our own container to avoid conflicts with theme-switcher
+    let colorPickerContainer = document.querySelector('.simple-color-picker');
     if (!colorPickerContainer) {
-      // Check if theme-controls exists
-      const themeControls = document.querySelector('.theme-controls');
-      if (themeControls) {
-        // Add to existing theme controls
-        colorPickerContainer = document.createElement('div');
-        colorPickerContainer.className = 'color-picker-container';
-        colorPickerContainer.innerHTML = colorPickerHTML;
-        themeControls.appendChild(colorPickerContainer);
-      } else {
-        // Create standalone container
-        colorPickerContainer = document.createElement('div');
-        colorPickerContainer.className = 'theme-controls color-picker-container';
-        colorPickerContainer.innerHTML = colorPickerHTML;
-        document.body.appendChild(colorPickerContainer);
-      }
+      colorPickerContainer = document.createElement('div');
+      colorPickerContainer.className = 'simple-color-picker';
+      colorPickerContainer.innerHTML = colorPickerHTML;
+      colorPickerContainer.style.cssText = 'position: fixed; bottom: 8rem; right: 2rem; z-index: 9998;';
+      document.body.appendChild(colorPickerContainer);
     }
 
     // Get elements


### PR DESCRIPTION
## Summary
- Fix favicon.ico 404 error
- Resolve color picker conflicts with theme-switcher

## Changes
1. **Fixed favicon path**: Added `{{ base_path }}` variable to favicon.ico link
2. **Separated color picker**: Use `.simple-color-picker` class to avoid conflicts

## Testing
- Favicon should load correctly without 404 errors
- Color picker should appear separately from theme switcher (bottom right)
- No JavaScript conflicts between the two components

🤖 Generated with [Claude Code](https://claude.ai/code)