### PR TITLE
Fix: Resolve syntax error in theme-switcher style injection

### DIFF
--- a/assets/js/theme-switcher-enhanced.js
+++ b/assets/js/theme-switcher-enhanced.js
@@ -424,9 +424,13 @@
     setTimeout(() => announcement.remove(), 1000);
   }
 
-  // Add enhanced styles
-  const enhancedStyles = `
-    <style id="theme-switcher-enhanced-styles">
+  // Create style element safely
+  function addEnhancedStyles() {
+    const styleElement = document.createElement('style');
+    styleElement.id = 'theme-switcher-enhanced-styles';
+    
+    // Define styles without HTML tags
+    const styleContent = `
       /* Enhanced Theme Panel Styles */
       .theme-controls {
         position: fixed;
@@ -668,17 +672,25 @@
         animation-duration: 0s !important;
         transition-duration: 0s !important;
       }
-    </style>
-  `;
+    `;
+    
+    // Set text content safely
+    styleElement.textContent = styleContent;
+    
+    // Add to head if not already present
+    if (!document.getElementById('theme-switcher-enhanced-styles')) {
+      document.head.appendChild(styleElement);
+    }
+  }
 
   // Initialize when DOM is ready
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', () => {
-      document.head.insertAdjacentHTML('beforeend', enhancedStyles);
+      addEnhancedStyles();
       init();
     });
   } else {
-    document.head.insertAdjacentHTML('beforeend', enhancedStyles);
+    addEnhancedStyles();
     init();
   }
 })();


### PR DESCRIPTION
## Summary
Fix the "Unexpected end of input" syntax error at position 14827

## Root Cause
The theme-switcher was using `insertAdjacentHTML` with a template literal containing `<style>` tags, which caused parsing issues.

## Solution
- Replace `insertAdjacentHTML` with safer `createElement` method
- Use `textContent` instead of innerHTML to avoid HTML parsing
- Remove `<style>` tags from the style content string

## Testing
1. The syntax error should no longer appear in the console
2. Theme switcher styles should still load correctly
3. Both theme switcher and color picker should work as expected

## Debug Info
From the debug tool:
- Style content length: 5490 characters
- Style syntax was valid
- Error occurred during HTML insertion

🤖 Generated with [Claude Code](https://claude.ai/code)