### PR TITLE
Fix: Final resolution for syntax error

### DIFF
--- a/assets/js/theme-switcher-enhanced.js
+++ b/assets/js/theme-switcher-enhanced.js
@@ -85,7 +85,9 @@
 
   // Create enhanced theme control UI
   function createThemeControls() {
-    const controlsHTML = `
+    // Create container element
+    const container = document.createElement('div');
+    container.innerHTML = `
       <div class="theme-controls">
         <button class="theme-panel-toggle" aria-label="Open theme settings" title="Theme Settings">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -153,7 +155,8 @@
       </div>
     `;
 
-    document.body.insertAdjacentHTML('beforeend', controlsHTML);
+    // Append the first child of container to body
+    document.body.appendChild(container.firstElementChild);
   }
 
   // Generate color theme HTML by category


### PR DESCRIPTION
## Summary
Replace the last remaining `insertAdjacentHTML` call to resolve the persistent syntax error

## Root Cause
Found another `insertAdjacentHTML` call in `createThemeControls()` function that was causing the "Unexpected end of input" error at position 14827

## Solution
- Replace `insertAdjacentHTML('beforeend', controlsHTML)` with safer DOM manipulation
- Use `createElement` + `innerHTML` + `appendChild` pattern
- This matches the fix applied to style injection in PR#18

## Testing
- The syntax error should be completely resolved
- Theme switcher should still work correctly
- Color picker functionality remains unaffected

This should be the final fix for the syntax error issue.

🤖 Generated with [Claude Code](https://claude.ai/code)