### PR TITLE
Style: Reduce hero name display size

### DIFF
--- a/_sass/_custom-overrides.scss
+++ b/_sass/_custom-overrides.scss
@@ -320,8 +320,8 @@ body {
 /* 2. Hero section improvements */
 .minimal-hero {
   position: relative;
-  padding: 4rem 0;
-  margin: -2rem -2rem 3rem;
+  padding: 2.5rem 0;
+  margin: -2rem -2rem 2rem;
   text-align: center;
   overflow: hidden;
   
@@ -341,9 +341,9 @@ body {
   }
   
   h1 {
-    font-size: 3rem;
-    font-weight: 700;
-    margin: 0 0 1rem;
+    font-size: 2.2rem;
+    font-weight: 600;
+    margin: 0 0 0.75rem;
     color: var(--text-color);
     opacity: 0;
     animation: fadeInUp 1s ease forwards;
@@ -351,7 +351,7 @@ body {
   }
   
   .subtitle {
-    font-size: 1.25rem;
+    font-size: 1.1rem;
     color: var(--text-light);
     max-width: 600px;
     margin: 0 auto;
@@ -501,15 +501,15 @@ body {
 /* 10. Responsive improvements */
 @media (max-width: 768px) {
   .minimal-hero {
-    margin: -1rem -1rem 2rem;
-    padding: 3rem 1rem;
+    margin: -1rem -1rem 1.5rem;
+    padding: 2rem 1rem;
     
     h1 {
-      font-size: 2rem;
+      font-size: 1.75rem;
     }
     
     .subtitle {
-      font-size: 1.1rem;
+      font-size: 1rem;
     }
   }
   


### PR DESCRIPTION
## Summary
Make the name display on the main page more modest and professional

## Changes
### Desktop sizes:
- **Name (h1)**: 3rem → 2.2rem (48px → 35px)
- **Font weight**: 700 → 600 (lighter)
- **Subtitle**: 1.25rem → 1.1rem

### Mobile sizes:
- **Name (h1)**: 2rem → 1.75rem (32px → 28px)
- **Subtitle**: 1.1rem → 1rem

### Spacing:
- Reduced padding and margins for a more compact display
- Better visual balance with the rest of the content

## Visual Impact
The name is now displayed at a more appropriate size that doesn't dominate the page, creating a more professional and balanced appearance.

🤖 Generated with [Claude Code](https://claude.ai/code)