### PR TITLE
[WD112] feat: Adjust sidebar height and enhance theme integration (PR#2)

### DIFF
--- a/_sass/_custom-overrides.scss
+++ b/_sass/_custom-overrides.scss
@@ -97,6 +97,25 @@ body {
   }
 }
 
+/* Sidebar theme integration */
+.sidebar {
+  @media screen and (min-width: $sidebar-screen-min-width) {
+    // Theme-aware background with transparency
+    background-color: var(--card-bg);
+    opacity: 0.98;
+    
+    // Dark mode specific adjustments
+    [data-theme="dark"] & {
+      box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+    }
+    
+    // Light mode specific adjustments
+    [data-theme="light"] & {
+      box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
+    }
+  }
+}
+
 /* Footer improvements */
 .page__footer {
   background: var(--card-bg);

--- a/_sass/layout/_sidebar.scss
+++ b/_sass/layout/_sidebar.scss
@@ -18,16 +18,19 @@
   }
 
   @media screen and (min-width: $sidebar-screen-min-width) {
-    height: 100vh;
+    height: auto;
+    max-height: calc(100vh - #{$masthead-height} - 2rem);
     overflow-y: auto;               // Add scrollbar if the sidebar is too long
     position: fixed;
-    padding-top: $masthead-height;
+    top: $masthead-height;
     
     // Add semi-transparent background for better readability
     background-color: var(--card-bg);
     backdrop-filter: blur(10px);
     -webkit-backdrop-filter: blur(10px);
-    padding: calc(#{$masthead-height} + 1rem) 1rem 1rem;
+    padding: 1rem 1rem 2rem;  // Reduced top padding, added bottom margin
+    margin-top: 1rem;         // Small gap from masthead
+    margin-bottom: 2rem;      // Bottom margin as requested
     border-radius: 0 8px 8px 0;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
   }


### PR DESCRIPTION
## Summary
- Adjust sidebar height to fit content instead of full viewport height
- Add proper margins (1rem top, 2rem bottom) for better visual balance
- Enhance theme integration with color-aware shadows

## Changes

### Sidebar Height Adjustment (_sass/layout/_sidebar.scss)
- Changed `height: 100vh` to `height: auto`
- Added `max-height` to prevent overflow on very tall content
- Set `top: $masthead-height` for proper positioning
- Adjusted padding: `1rem 1rem 2rem` (reduced top, increased bottom)
- Added `margin-top: 1rem` for gap from masthead
- Added `margin-bottom: 2rem` as requested

### Theme Integration (_sass/_custom-overrides.scss)
- Added theme-aware sidebar styles
- Different shadow intensities for light/dark modes
- Slight opacity adjustment for better blending

## Test plan
- [ ] Build passes without errors
- [ ] Sidebar height adjusts to content properly
- [ ] Background only covers content area, not full viewport
- [ ] Proper margins visible above avatar and below social links
- [ ] Theme switching maintains proper appearance
- [ ] No regression on mobile views

🤖 Generated with [Claude Code](https://claude.ai/code)