### PR TITLE
[WD112] feat: Position hero text to bottom-right

### DIFF
--- a/_sass/layout/_page.scss
+++ b/_sass/layout/_page.scss
@@ -132,6 +132,11 @@
     .wrapper {
       padding-left: 1em;
       padding-right: 1em;
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-end;
+      align-items: flex-end;
+      min-height: 300px;
 
       @include breakpoint($x-large) {
         max-width: $x-large;
@@ -148,10 +153,14 @@
 
     .page__lead {
       max-width: $medium;
+      text-align: right;
+      margin-bottom: 0.5rem;
     }
 
     .page__title {
       font-size: $type-size-2;
+      text-align: right;
+      margin-bottom: 0.5rem;
 
       @include breakpoint($small) {
         font-size: $type-size-1;


### PR DESCRIPTION
## Summary
- Move page title and subtitle to bottom-right corner of hero banner
- Improve text alignment and positioning for better visual hierarchy

## Changes in _sass/layout/_page.scss

### Hero Wrapper Layout
- Added `display: flex` with `flex-direction: column`
- Set `justify-content: flex-end` and `align-items: flex-end`
- Added `min-height: 300px` to ensure consistent banner height

### Text Positioning
- **Page Title**: Right-aligned with `margin-bottom: 0.5rem`
- **Page Lead (subtitle)**: Right-aligned with `margin-bottom: 0.5rem`
- Both elements now appear in the bottom-right corner

## Test plan
- [ ] Build passes without errors
- [ ] Title "About" appears in bottom-right
- [ ] Subtitle "Neuroscience PhD Student..." appears in bottom-right
- [ ] Text remains readable with shadow effect
- [ ] Responsive behavior works correctly
- [ ] No overlap with other elements

🤖 Generated with [Claude Code](https://claude.ai/code)