### PR TITLE
[WD112] fix: Remove all remaining banner captions

### DIFF
--- a/_pages/publications.html
+++ b/_pages/publications.html
@@ -6,7 +6,6 @@ author_profile: true
 header:
   overlay_image: "hero/hero-network-4.png"
   overlay_filter: 0.4
-  caption: "Research Publications & Academic Output"
 ---
 
 {% if site.author.googlescholar %}

--- a/_pages/research-timeline.html
+++ b/_pages/research-timeline.html
@@ -6,7 +6,6 @@ author_profile: true
 header:
   overlay_image: "hero/hero-brain.png"
   overlay_filter: 0.4
-  caption: "Neural Networks & Brain Research"
 ---
 
 {% include base_path %}

--- a/_pages/year-archive.html
+++ b/_pages/year-archive.html
@@ -9,7 +9,6 @@ classes: blog-archive
 header:
   overlay_image: "hero/hero-network-2.png"
   overlay_filter: 0.3
-  caption: "Thoughts, Ideas & Academic Reflections"
 ---
 
 {% include base_path %}


### PR DESCRIPTION
## Summary
Remove banner captions from all remaining pages to maintain consistency across the site.

## Changes
- Removed caption from `_pages/year-archive.html` ("Thoughts, Ideas & Academic Reflections")
- Removed caption from `_pages/publications.html` ("Research Publications & Academic Output")
- Removed caption from `_pages/research-timeline.html` ("Neural Networks & Brain Research")

## Test plan
- [ ] Build passes without errors
- [ ] No captions appear on any banner images
- [ ] All pages maintain proper layout

🤖 Generated with [Claude Code](https://claude.ai/code)